### PR TITLE
Fixes an issue because Topcoder APIs aren’t compliant with how nulls …

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -436,6 +436,9 @@
    * @returns An instance of the specified type.
    */
   exports.convertToType = function(data, type) {
+    if(data == null) {
+      return null;
+    }
     switch (type) {
       case 'Boolean':
         return Boolean(data);


### PR DESCRIPTION
…are handled